### PR TITLE
fix(ytdlp): guard uninstall and dependency checks in container environments

### DIFF
--- a/etc/ytdlp/yt-dlp-launcher.sh
+++ b/etc/ytdlp/yt-dlp-launcher.sh
@@ -336,7 +336,7 @@ home_menu() {
         echo "2. Download video"
         echo "3. Editor"
         echo "4. Update"
-        echo "5. Uninstall yt-dlp"
+        if [ ! -f /.dockerenv ]; then echo '5. Uninstall yt-dlp'; fi
         echo "0. Exit"
 
         read -p "Choose Your Destiny: " choice
@@ -346,7 +346,7 @@ home_menu() {
             2) download_media "video" ;;
             3) editor_menu ;;
             4) update_ytdlp ;;
-            5) uninstall_ytdlp ;;
+            5) if [ ! -f /.dockerenv ]; then uninstall_ytdlp; else error "Uninstall is not available in container mode."; pause; fi ;;
             0) exit_ytdlp ;;
             *) error "$echo_invalidinput"; pause ;;
         esac
@@ -824,7 +824,9 @@ main() {
     load_settings
 
     # Check for system dependencies like curl, ffmpeg
-    check_dependencies
+    if [ ! -f /.dockerenv ]; then
+        check_dependencies
+    fi
 
     # Check if yt-dlp exists, if not, download it
     if [ ! -f "$ytdlp_executable" ]; then


### PR DESCRIPTION
## Summary

Follow-up to the earlier launcher work.

Since the previous PR, I’ve continued building around this launcher in a containerized/web-managed environment, and that real-world use exposed a few issues that are worth fixing upstream.

This PR only covers the launcher-side containerized pieces that came out of that use.

## What this changes
- hides the uninstall menu option when running inside a container
- blocks uninstall if invoked in a container context
- skips dependency installation checks in a container context

## Why
These came out of actual use of the launcher in a containerized environment.
In that context:

- uninstalling yt-dlp is not a sensible launcher action
- the dependency check/install path can fail because it assumes a host-style package/sudo flow that may not exist there

These guards make the launcher behave sanely in container use without changing normal non-container behavior.

## Context
I’ve done more work around this launcher on my side since the earlier PR, including broader
packaging/runtime changes, but I’m intentionally **not** trying to roll all of that upstream here.

This PR is only the small launcher-side piece.

## Scope
- 1 file: etc/ytdlp/yt-dlp-launcher.sh,
- small container-specific guards only,
- no web UI changes,
- no unrelated launcher refactor.
